### PR TITLE
Use ruby with RVM

### DIFF
--- a/raf-emacs/layers.el
+++ b/raf-emacs/layers.el
@@ -13,7 +13,7 @@
                                       shell
                                       (shell :variables shell-default-shell 'ansi-term)
                                       (shell :variables shell-default-term-shell "/bin/zsh")
-                                      ruby
+                                      (ruby :variables ruby-version-manager 'rvm)
                                       ruby-on-rails
                                       html
                                       gtags


### PR DESCRIPTION
Add RVM to the ruby configuration in order to find the related gems in the project context